### PR TITLE
Do not traback when asset cannot be found

### DIFF
--- a/fig/backends/gcp/__init__.py
+++ b/fig/backends/gcp/__init__.py
@@ -96,6 +96,7 @@ class Submitter():
             finding = self.finding()
         except AssetNotFound:
             log.warning("Corresponding asset not found in GCP Project")
+            return
 
         self.submit_finding(finding)
 


### PR DESCRIPTION
```
Addressing:
Traceback (most recent call last):
  File "/fig/fig/worker.py", line 18, in run
    self.process_event(event)
  File "/fig/fig/worker.py", line 28, in process_event
    self.backends.process(falcon_event)
  File "/fig/fig/backends/__init__.py", line 15, in process
    runtime.process(falcon_event)
  File "/fig/fig/backends/gcp/__init__.py", line 198, in process
    Submitter(self.cache, falcon_event).submit()
  File "/fig/fig/backends/gcp/__init__.py", line 100, in submit
    self.submit_finding(finding)
UnboundLocalError: local variable 'finding' referenced before assignment
```