### PR TITLE
Do not run RTR commands when workspaceone is disabled

### DIFF
--- a/fig/backends/__init__.py
+++ b/fig/backends/__init__.py
@@ -21,15 +21,7 @@ class Backends():
         if len(self.runtimes) == 0:
             raise Exception("No Backend enabled. Exiting.")
 
-    def runtime(self, cloud_provider):
-        # Convert the cloud_provider field from Falcon API to internal backend name
-        if cloud_provider == 'AWS_EC2':
-            cloud_provider = 'AWS'
-        return self.runtimes.get(cloud_provider)
-
     def process(self, falcon_event):
-        runtime = self.runtime(falcon_event.cloud_provider)
-        if runtime:
-            runtime.process(falcon_event)
-        if falcon_event.mdm_identifier is not None:
-            self.runtimes.get('WORKSPACEONE').process(falcon_event)
+        for runtime in self.runtimes.values():
+            if runtime.is_relevant(falcon_event):
+                runtime.process(falcon_event)

--- a/fig/backends/__init__.py
+++ b/fig/backends/__init__.py
@@ -15,13 +15,13 @@ ALL_BACKENDS = {
 
 class Backends():
     def __init__(self):
-        self.runtimes = {k: v.Runtime()
+        self.runtimes = [v.Runtime()
                          for k, v in ALL_BACKENDS.items()
-                         if k in config.backends}
+                         if k in config.backends]
         if len(self.runtimes) == 0:
             raise Exception("No Backend enabled. Exiting.")
 
     def process(self, falcon_event):
-        for runtime in self.runtimes.values():
+        for runtime in self.runtimes:
             if runtime.is_relevant(falcon_event):
                 runtime.process(falcon_event)

--- a/fig/backends/aws/__init__.py
+++ b/fig/backends/aws/__init__.py
@@ -75,6 +75,9 @@ class Runtime():
             self.queue = None
             raise
 
+    def is_relevant(self, falcon_event):  # pylint: disable=R0201
+        return falcon_event.cloud_provider == 'AWS_EC2'
+
     def process(self, falcon_event):  # pylint: disable=R0201
         Submitter(self.queue, falcon_event).submit()
 

--- a/fig/backends/azure/__init__.py
+++ b/fig/backends/azure/__init__.py
@@ -74,6 +74,9 @@ class Runtime():
     def __init__(self):
         log.info("Azure Backend is enabled.")
 
+    def is_relevant(self, falcon_event):  # pylint: disable=R0201
+        return falcon_event.cloud_provider == 'AZURE'
+
     def process(self, falcon_event):  # pylint: disable=R0201
         Submitter(falcon_event).submit()
 

--- a/fig/backends/gcp/__init__.py
+++ b/fig/backends/gcp/__init__.py
@@ -196,6 +196,9 @@ class Runtime():
         log.info("GCP Backend is enabled.")
         self.cache = Cache()
 
+    def is_relevant(self, falcon_event):  # pylint: disable=R0201
+        return falcon_event.cloud_provider == 'GCP'
+
     def process(self, falcon_event):
         Submitter(self.cache, falcon_event).submit()
 

--- a/fig/backends/workspaceone/__init__.py
+++ b/fig/backends/workspaceone/__init__.py
@@ -100,6 +100,9 @@ class Runtime():
             }
         })
 
+    def is_relevant(self, falcon_event):  # pylint: disable=R0201
+        return falcon_event.mdm_identifier is not None
+
     def process(self, falcon_event):
         Submitter(self.workspaceone_token, falcon_event).submit()
 


### PR DESCRIPTION
 - Provide unified interface to let each backend elect whether given event is
   relevant to it.
 - Do not run workspaceone backend when it is not enabled
 - Clean-up common code from backend-specific if/else-s

Addressing errors like:
```
Traceback (most recent call last):
  File "/fig/fig/worker.py", line 18, in run
    self.process_event(event)
  File "/fig/fig/worker.py", line 28, in process_event
    self.backends.process(falcon_event)
  File "/fig/fig/backends/__init__.py", line 34, in process
    if falcon_event.mdm_identifier is not None:
  File "/fig/fig/falcon_data.py", line 78, in mdm_identifier
    return self.cache.mdm_identifier(self.original_event.sensor_id)
  File "/fig/fig/falcon_data.py", line 49, in mdm_identifier
    session = self.falcon_api.init_rtr_session(sensor_id)
  File "/fig/fig/falcon/api.py", line 55, in init_rtr_session
    return self._resources(
  File "/fig/fig/falcon/api.py", line 82, in _resources
    response = self._command(*args, **kwargs)
  File "/fig/fig/falcon/api.py", line 93, in _command
    raise ApiError('Error received from CrowdStrike Falcon platform: {}'.format(body['errors']))
fig.falcon.api.ApiError: Error received from CrowdStrike Falcon platform: [{'code': 40020, 'message': 'Sensor appears too old.  Please upgrade.'}]
```