### PR TITLE
Do not re-process the very last even, after falcon stream re-connected

### DIFF
--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -121,7 +121,7 @@ class StreamingConnection():
             'Connection': 'Keep-Alive'
         }
         log.info("Opening Streaming Connection")
-        url = self.stream.url + '&offset={}'.format(self.last_seen_offset)
+        url = self.stream.url + '&offset={}'.format(self.last_seen_offset + 1 if self.last_seen_offset != 0 else 0)
         self.connection = requests.get(url, headers=headers, stream=True)
         return self.connection
 


### PR DESCRIPTION
Plus one problem.

Previously, we would process the very last detection event after each falcon
stream re-connect. This behavior had no notable side-effect for GCP. GCP backend
was able to recognize the SCC finding is already present and thus skip it.
Nevertheless with new backends like Workspaceone where we just push the event
through, we may want to not re-process events that nonchalantly.