### PR TITLE
Increase the time we give to CrowdStrike cloud to time-out on the streaming

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -16,6 +16,7 @@ cloud_region = us-1
 client_id =
 client_secret =
 application_id = fig-gcp
+reconnect_retry_count = 36
 
 [gcp]
 # Use GOOGLE_APPLICATION_CREDENTIALS env variable

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -43,6 +43,8 @@ class FigConfig(configparser.SafeConfigParser):
             raise Exception('Malformed configuration: expected events.older_than_days_threshold to be in range 0-10000')
         if int(self.get('main', 'worker_threads')) not in range(1, 128):
             raise Exception('Malformed configuration: expected main.worker_threads to be in range 1-128')
+        if int(self.get('falcon', 'reconnect_retry_count')) not in range(1, 10000):
+            raise Exception('Malformed configuration: expected falcon.reconnect_retry_count to be in range 0-10000')
         self.validate_backends()
 
     def validate_backends(self):

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -40,7 +40,7 @@ class StreamManagementThread(threading.Thread):
         return stop_event
 
     def get_streams(self, falcon_api):
-        retry_count = 36  # 360 seconds or 6 minutes to let the cloud time-out
+        retry_count = int(config.get('falcon', 'reconnect_retry_count'))
         for attempt in range(retry_count):
             try:
                 return falcon_api.streams(self.application_id)

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -40,7 +40,7 @@ class StreamManagementThread(threading.Thread):
         return stop_event
 
     def get_streams(self, falcon_api):
-        retry_count = 5
+        retry_count = 36  # 360 seconds or 6 minutes to let the cloud time-out
         for attempt in range(retry_count):
             try:
                 return falcon_api.streams(self.application_id)


### PR DESCRIPTION


Sometimes, 50 seconds is just not enough. The scientific decision is to bump this big and see if we can observe any hazards.