### PR TITLE
Replace unacceptable widget name

### DIFF
--- a/docs/listings/gke/deployer/schema.yaml
+++ b/docs/listings/gke/deployer/schema.yaml
@@ -61,6 +61,6 @@ required:
 - cloud.google.application_credentials
 
 form:
-- widget: Deployment Guide
+- widget: help
   description: |-
     <a href="https://github.com/CrowdStrike/falcon-integration-gateway/blob/main/docs/listings/gke/UserGuide.md">Deployment Guide</a>


### PR DESCRIPTION
Addressing:
```
=== SCHEMA VALIDATION WARNING ===
WARNING: Schema is incompatible with the latest deployer, would fail with:

Traceback (most recent call last):
  File "/bin/validate_schema.py", line 35, in <module>
    main()
  File "/bin/validate_schema.py", line 31, in main
    schema_values_common.load_schema_and_validate(args)
  File "/bin/schema_values_common.py", line 65, in load_schema_and_validate
    return load_schema(parsed_args).validate()
  File "/bin/config_helper.py", line 158, in validate
    item['widget']))
config_helper.InvalidSchema: Unrecognized form widget: Deployment Guide
======== END OF WARNING =========
=== ERROR SUMMARY ===
ERROR Deployer failed
```