### PR TITLE
AWS: Fix undefined variable

### DIFF
--- a/fig/backends/aws/__init__.py
+++ b/fig/backends/aws/__init__.py
@@ -62,6 +62,7 @@ class Submitter():
 
     def submit(self):
         log.info("Processing detection: %s", self.event.detect_description)
+        det_region = config.get('aws', 'region')
         send = False
         try:
             if self.event.instance_id:


### PR DESCRIPTION
Previously, det_region variable was not defined if instance_id was not provided by Falcon platform.

