### PR TITLE
Pin to the older dependency version to avoid api breakages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 crowdstrike-falconpy
 google-cloud-securitycenter
-google-cloud-resource-manager
+google-cloud-resource-manager < 0.40
 tls-syslog

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'boto3',
         'crowdstrike-falconpy',
         'google-cloud-securitycenter',
-        'google-cloud-resource-manager',
+        'google-cloud-resource-manager < 0.40',
         'tls-syslog'
     ],
     extras_require={


### PR DESCRIPTION
Obviously, this is an interim solution. Proper fix is to rewrite our autodiscovery code to adopt the latest GCP resourcemanager v3 API.