### PR TITLE
Updating for OAuth2

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -67,8 +67,11 @@
 [chronicle]
 # Chronicle section is applicable only when Chronicle backend is enabled in the [main] section
 
-# Uncomment to provide Google security key. Alternatively, use GOOGLE_SECURITY_KEY env variable
-#security_key =
+# Uncomment to provide Google Service Account filepath. Alternatively, use GOOGLE_SERVICE_ACCOUNT_FILE variable
+#service_account = apikeys-demo.json
+
+# Uncomment to provide Chronicle Customer ID. Alternatively, use GOOGLE_CUSTOMER_ID variable
+#customer_id = XXX
 
 # Uncomment to provide Chronicle region (us, europe, asia-southeast1). Alternatively, use CHRONICLE_REGION variable
 #region =

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -35,5 +35,5 @@ syslog_host =
 syslog_port = 6514
 
 [chronicle]
-security_key =
+service_account =
 region =

--- a/fig/backends/chronicle/__init__.py
+++ b/fig/backends/chronicle/__init__.py
@@ -41,7 +41,7 @@ class Submitter():
 
     def submit(self, event):
         self.event = event
-        log.info("Processing detection: %s", self.event.detect_description)
+        log.info("Processing detection: %s", self.event.original_event['event']['DetectId'])
         self.post_to_chronicle(self.udm(), self.region, self.customer_id)
 
     # Maps detection events into UDM
@@ -114,10 +114,10 @@ class Submitter():
         response = self.http_client.post(url, data=dumps(payload), headers=headers)
         # Log any errors
         if response.status_code < 200 or response.status_code > 299:
-            log.error(f"Error posting detection to Chronicle: {response.text}")
+            log.error(f"Error posting {detection['metadata']['product_log_id']} to Chronicle: {response.text}")
             log.error(f"Faulty detection: {dumps(payload, indent=4, sort_keys=True)}")
         else:
-            log.info(f"Successfully posted detection to Chronicle:\t Byte count: {utf8len(dumps(payload))}")
+            log.info(f"Successfully posted {detection['metadata']['product_log_id']} to Chronicle:\t Byte count: {utf8len(dumps(payload))}")
 
     def build_http_client(self):
         service_account_file = config.get('chronicle', 'service_account_file')

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -15,7 +15,8 @@ class FigConfig(configparser.SafeConfigParser):
         ['workspaceone', 'token', 'WORKSPACEONE_TOKEN'],
         ['workspaceone', 'syslog_host', 'SYSLOG_HOST'],
         ['workspaceone', 'syslog_port', 'SYSLOG_PORT'],
-        ['chronicle', 'security_key', 'GOOGLE_SECURITY_KEY'],
+        ['chronicle', 'service_account', 'GOOGLE_SERVICE_ACCOUNT_FILE'],
+        ['chronicle', 'customer_id', 'GOOGLE_CUSTOMER_ID'],
         ['chronicle', 'region', 'CHRONICLE_REGION']
     ]
 
@@ -72,10 +73,12 @@ class FigConfig(configparser.SafeConfigParser):
             if int(self.get('workspaceone', 'syslog_port')) not in range(1, 65535):
                 raise Exception('Malformed configuration: expected workspaceone.syslog_port to be in range 1-65335')
         if 'CHRONICLE' in self.backends:
-            if len(self.get('chronicle', 'security_key')) == 0:
-                raise Exception('Malformed Configuration: expected chronicle.security_key to be non-empty')
+            if len(self.get('chronicle', 'service_account_file')) == 0:
+                raise Exception('Malformed Configuration: expected chronicle.service_account_file to be non-empty')
             if len(self.get('chronicle', 'region')) == 0:
                 raise Exception('Malformed Configuration: expected chronicle.region to be non-empty')
+            if len(self.get('chronicle', 'customer_id')) == 0:
+                raise Exception('Malformed Configuration: expected chronicle.customer_id to be non-empty')
         if 'AZURE' in self.backends:
             if len(self.get('azure', 'workspace_id')) == 0:
                 raise Exception('Malformed Configuration: expected azure.workspace_id to be non-empty')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ crowdstrike-falconpy
 google-cloud-securitycenter
 google-cloud-resource-manager >= 1.0.2
 tls-syslog
+google-auth
+google-api-python-client

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ setup(
         'crowdstrike-falconpy',
         'google-cloud-securitycenter',
         'google-cloud-resource-manager >= 1.0.2',
-        'tls-syslog'
+        'tls-syslog',
+        'google-auth',
+        'google-api-python-client'
     ],
     extras_require={
         'devel': [


### PR DESCRIPTION
Chronicle has decommissioned the legacy Security Key Auth for submitting events. This update replaces that auth with a Service Account Approach documented [here](https://cloud.google.com/chronicle/docs/reference/ingestion-api#how_to_authenticate_with_the_api)