### PR TITLE
Provide default nil value for chronicle.customer_id

### DIFF
--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -37,3 +37,4 @@ syslog_port = 6514
 [chronicle]
 service_account =
 region =
+customer_id =


### PR DESCRIPTION
This is crucial for use-cases when chronicle backend is disabled, but the config
parser still expects the value for it.

Addressing:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/configparser.py", line 790, in get
    value = d[option]
  File "/usr/local/lib/python3.10/collections/__init__.py", line 986, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/local/lib/python3.10/collections/__init__.py", line 978, in __missing__
    raise KeyError(key)
KeyError: 'customer_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/fig/fig/config/__init__.py", line 37, in validate
    self.get(section, var)
  File "/usr/local/lib/python3.10/configparser.py", line 793, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'customer_id' in section: 'chronicle'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/fig/fig/__main__.py", line 13, in <module>
    config.validate()
  File "/fig/fig/config/__init__.py", line 39, in validate
    raise Exception(
Exception: Please provide environment variable GOOGLE_CUSTOMER_ID or configuration option chronicle.customer_id
```