### PR TITLE
update chronicle backend

### DIFF
--- a/fig/backends/chronicle/__init__.py
+++ b/fig/backends/chronicle/__init__.py
@@ -49,7 +49,7 @@ class Submitter():
     def udm(self):
         event = self.event.original_event['event']
         meta = self.event.original_event['metadata']
-        timestamp_components = str(datetime.fromtimestamp(event["ProcessStartTime"])).split()
+        timestamp_components = str(datetime.fromtimestamp(event["UTCTimestamp"])).split()
         new_url = parse_url(event["FalconHostLink"])
         udm_result = {
             "metadata": {


### PR DESCRIPTION
Currently we use the process start time as the events timestamp. From feedback this should be instead the UTCTimestamp as often times a process may be running for a while before a detection is emitted. This will help to remove the delta between the detection being emitted and the time that Chronicle logs the event as occurring. As it stands, long running processes are causing Chronicle to not emit alerts at ingestion time due it thinking the event has occurred in the past. 