### PR TITLE
Improve and increase logging and debug loggin

### DIFF
--- a/fig/backends/__init__.py
+++ b/fig/backends/__init__.py
@@ -5,6 +5,7 @@ from . import azure
 from . import gcp
 from . import workspaceone
 from ..config import config
+from ..log import log
 
 
 ALL_BACKENDS = {
@@ -24,6 +25,12 @@ class Backends():
                          if k in config.backends]
         if len(self.runtimes) == 0:
             raise Exception("No Backend enabled. Exiting.")
+
+        accepted_types = self.relevant_event_types
+        if accepted_types is None:
+            log.info("At least one of the enabled backends will receive all the events")
+        else:
+            log.info("Enabled backends will only process events with types: %s", accepted_types)
 
     def process(self, falcon_event):
         for runtime in self.runtimes:

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -125,6 +125,7 @@ class StreamingConnection():
         log.info("Opening Streaming Connection")
         url = self.stream.url + '&offset={}'.format(self.last_seen_offset + 1 if self.last_seen_offset != 0 else 0)
         self.connection = requests.get(url, headers=headers, stream=True, timeout=60)
+        log.info("Established Streaming Connection: %d %s", self.connection.status_code, self.connection.reason)
         return self.connection
 
     def events(self):

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -88,6 +88,7 @@ class StreamingThread(StoppableThread):
         self.queue = queue
         self.relevant_event_types = relevant_event_types
         self.event_count = 0
+        self.event_count_types = {}
 
     def run(self):
         try:
@@ -107,8 +108,6 @@ class StreamingThread(StoppableThread):
                 self.conn.close()
 
     def process_event(self, event):
-        if log.level <= logging.DEBUG:
-            self.log_event()
         event = Event(event)
         if log.level <= logging.DEBUG:
             self.log_event(event)
@@ -116,10 +115,11 @@ class StreamingThread(StoppableThread):
         if (self.relevant_event_types is None or event.event_type in self.relevant_event_types) and not event.irrelevant():
             self.queue.put(event)
 
-    def log_event(self):
+    def log_event(self, event):
         self.event_count += 1
+        self.event_count_types[event.event_type] = self.event_count_types.get(event.event_type, 0) + 1
         if self.event_count % 200 == 0:
-            log.debug("Received %d events from the stream", self.event_count)
+            log.debug("Received %d events from the stream. Type breakdown was: %s", self.event_count, self.event_count_types)
 
 
 class StreamingConnection():

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -126,6 +126,7 @@ class StreamingConnection():
         url = self.stream.url + '&offset={}'.format(self.last_seen_offset + 1 if self.last_seen_offset != 0 else 0)
         self.connection = requests.get(url, headers=headers, stream=True, timeout=60)
         log.info("Established Streaming Connection: %d %s", self.connection.status_code, self.connection.reason)
+        self.connection.raise_for_status()
         return self.connection
 
     def events(self):


### PR DESCRIPTION
Example output:
```
2022-09-22 13:13:09 fig MainThread INFO     GCP Backend is enabled.
2022-09-22 13:13:09 fig MainThread INFO     Enabled backends will only process events with types: {'DetectionSummaryEvent'}
2022-09-22 13:13:10 fig cs_stream  INFO     Opening Streaming Connection
2022-09-22 13:13:16 fig cs_stream  INFO     Established Streaming Connection: 200 OK
2022-09-22 13:13:20 fig cs_stream  DEBUG    Received 200 events from the stream. Type breakdown was: {'UserActivityAuditEvent': 78, 'AuthActivityAuditEvent': 120, 'RemoteResponseSessionStartEvent': 1, 'RemoteResponseSessionEndEvent': 1}

......

2022-09-22 13:13:33 fig cs_stream  DEBUG    Received 5600 events from the stream. Type breakdown was: {'UserActivityAuditEvent': 2362, 'AuthActivityAuditEvent': 3117, 'RemoteResponseSessionStartEvent': 54, 'RemoteResponseSessionEndEvent': 54, 'IncidentSummaryEvent': 4, 'DetectionSummaryEvent': 9}
```