### PR TITLE
Support the use of feed_id as an identifier for offsets

### DIFF
--- a/fig/falcon/models.py
+++ b/fig/falcon/models.py
@@ -5,9 +5,15 @@ from ..config import config
 
 
 class Event(dict):
-    def __init__(self, event_string):
+    def __init__(self, event_string, feed_id):
         event = json.loads(event_string.decode('utf-8'))
+        self.feed_id = feed_id
         super().__init__(event)
+
+    def __eq__(self, other):
+        if not isinstance(other, Event):
+            return False
+        return super().__eq__(self, other) and self.feed_id == other.feed_id
 
     def irrelevant(self):
         return self.severity < int(config.get('events', 'severity_threshold')) \
@@ -20,6 +26,10 @@ class Event(dict):
     @property
     def offset(self):
         return self['metadata']['offset']
+
+    @property
+    def uid(self):
+        return str(self.feed_id) + '_' + str(self.offset)
 
     @property
     def severity(self):
@@ -61,4 +71,12 @@ class Stream(dict):
                          self['refreshActiveSessionURL'])
         if not match or not match.group(1):
             raise Exception('Cannot parse stream partition from stream data: {}'.format(self))
+        return match.group(1)
+
+    @property
+    def feed_id(self):
+        match = re.match(r'.*\/sensors\/entities\/datafeed/v1/([0-9a-zA-Z]+)\?',
+                         self['dataFeedURL'])
+        if not match or not match.group(1):
+            raise Exception('Cannot parse Feed ID from stream data: {}'.format(self))
         return match.group(1)

--- a/fig/falcon/stream.py
+++ b/fig/falcon/stream.py
@@ -84,7 +84,8 @@ class StreamingThread(StoppableThread):
     def __init__(self, stream: Stream, queue, relevant_event_types, *args, **kwargs):
         kwargs['name'] = kwargs.get('name', 'cs_stream')
         super().__init__(*args, **kwargs)
-        self.conn = StreamingConnection(stream, queue.last_offset())
+        self.stream = stream
+        self.conn = StreamingConnection(self.stream, queue.last_offset(self.stream.feed_id))
         self.queue = queue
         self.relevant_event_types = relevant_event_types
         self.event_count = 0
@@ -108,7 +109,7 @@ class StreamingThread(StoppableThread):
                 self.conn.close()
 
     def process_event(self, event):
-        event = Event(event)
+        event = Event(event, self.stream.feed_id)
         if log.level <= logging.DEBUG:
             self.log_event(event)
 

--- a/fig/queue/__init__.py
+++ b/fig/queue/__init__.py
@@ -5,17 +5,18 @@ import threading
 class FalconEvents(queue.Queue):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.offset = 0
+        self.offset = {}
         self._lock = threading.Lock()
 
-    def last_offset(self):
-        return self.offset
+    def last_offset(self, feed_id):
+        return self.offset.get(feed_id, 0)
 
     def get(self, *args, **kwargs):
         event = super().get(*args, **kwargs)
+        feed_id = event.feed_id
         offset = event.offset
         with self._lock:
-            self.offset = max(offset, self.offset)
+            self.offset[feed_id] = max(offset, self.last_offset(feed_id))
         return event
 
 


### PR DESCRIPTION
Supports the use of feed_id as an identifier to Events. This allows us to create a unique identifier, which is the combination of feed_id + offset in backends where a unique identifier may be required in the payload. This can also allow for better debugging when using multiple feeds.