### PR TITLE
Azure Log Analytics: Ingest detection even when originated outside of Azure

### DIFF
--- a/fig/backends/azure/__init__.py
+++ b/fig/backends/azure/__init__.py
@@ -80,7 +80,7 @@ class Runtime():
         log.info("Azure Backend is enabled.")
 
     def is_relevant(self, falcon_event):
-        return falcon_event.cloud_provider == 'AZURE'
+        return True
 
     def process(self, falcon_event):
         Submitter(falcon_event).submit()


### PR DESCRIPTION
This filter has been originally introduced for GCP SCC (Security Command Center). GCP SCC cannot ingest events for assets that are not in GCP (you cannot create reportable asset that is not inside GCP). Similar situation applies to AWS Security Hub, I believe. When VM is not known to AWS Security Hub, you can submit finding, but it won’t be classified that well.

On the other hand, we won’t apply any filtering when streaming events to Chronicle of VMWare WorkspaceONE.

Given the Log Analytics system resembles Chronicle rather than GCP SCC, I am inclined to remove the filter altogether.