### PR TITLE
Added env vars to all config.ini options + changed default app_id

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1,21 +1,26 @@
 # Falcon Integration Gateway
 
 [main]
-# Cloud backends that are enabled. The gateway will push events to the cloud providers specified below
-#backends = AWS,AZURE,GCP,WORKSPACEONE,CHRONICLE
+# Uncomment to enable backends. Alternatively, use FIG_BACKENDS env variable.
+# The gateway will push events to the cloud providers specified below
+#backends = AWS,AWS_SQS,AZURE,GCP,WORKSPACEONE,CHRONICLE,
 
-# Uncomment to configure number of threads that process Falcon Events
+# Uncomment to configure number of threads that process Falcon Events. Alternatively,
+# use FIG_WORKER_THREADS env variable.
 #worker_threads = 4
 
 [events]
-# Uncomment to filter out events based on severity (allowed values 1-5, default 2)
+# Uncomment to filter out events based on severity (allowed values 1-5, default 2).
+# Alternatively, use EVENTS_SEVERITY_THRESHOLD env variable.
 #severity_threshold = 3
 
-# Uncomment to filter out events based on number of days past the event (default 21)
+# Uncomment to filter out events based on number of days past the event (default 21).
+# Alternatively, use EVENTS_OLDER_THAN_DAYS_THRESHOLD env variable.
 #older_than_days_threshold = 14
 
 [logging]
-# Uncomment to request logging level (ERROR, WARN, INFO, DEBUG)
+# Uncomment to request logging level (ERROR, WARN, INFO, DEBUG). Alternatively, use
+# LOG_LEVEL env variable.
 #level = DEBUG
 
 [falcon]
@@ -29,6 +34,7 @@
 #client_secret = ABCD
 
 # Uncomment to provide application id. Needs to be different per each fig instance.
+# Alternatively, use FALCON_APPLICATION_ID env variable.
 #application_id = my-acme-gcp-1
 
 [gcp]
@@ -48,7 +54,6 @@
 
 [aws]
 # AWS section is applicable only when AWS backend is enabled in the [main] section.
-# AWS Backend publishes Falcon Detection events to AWS Security Hub
 
 # Uncomment to provide aws region. Alternatively, use AWS_REGION env variable
 #region = eu-west-1

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -15,7 +15,7 @@ level = INFO
 cloud_region = us-1
 client_id =
 client_secret =
-application_id = fig-gcp
+application_id = fig-default-app-id
 reconnect_retry_count = 36
 
 [gcp]

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -6,9 +6,16 @@ class FigConfig(configparser.SafeConfigParser):
     ALL_BACKENDS = {'AWS', 'AWS_SQS', 'AZURE', 'GCP', 'WORKSPACEONE', 'CHRONICLE'}
     FALCON_CLOUD_REGIONS = {'us-1', 'us-2', 'eu-1', 'us-gov-1'}
     ENV_DEFAULTS = [
+        ['main', 'backends', 'FIG_BACKENDS'],
+        ['main', 'worker_threads', 'FIG_WORKER_THREADS'],
+        ['logging', 'level', 'LOG_LEVEL'],
+        ['events', 'severity_threshold', 'EVENTS_SEVERITY_THRESHOLD'],
+        ['events', 'older_than_days_threshold', 'EVENTS_OLDER_THAN_DAYS_THRESHOLD'],
         ['falcon', 'cloud_region', 'FALCON_CLOUD_REGION'],
         ['falcon', 'client_id', 'FALCON_CLIENT_ID'],
         ['falcon', 'client_secret', 'FALCON_CLIENT_SECRET'],
+        ['falcon', 'reconnect_retry_count', 'FALCON_RECONNECT_RETRY_COUNT'],
+        ['falcon', 'application_id', 'FALCON_APPLICATION_ID'],
         ['azure', 'workspace_id', 'WORKSPACE_ID'],
         ['azure', 'primary_key', 'PRIMARY_KEY'],
         ['aws', 'region', 'AWS_REGION'],


### PR DESCRIPTION
All config options should have corresponding ENV variables to facilitate passing/changing configurations without using/passing a config.ini file.

Also changed the default application id to something more generic.