### PR TITLE
Enable detection filtering based on cloud the instance resides in

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -18,6 +18,9 @@
 # Alternatively, use EVENTS_OLDER_THAN_DAYS_THRESHOLD env variable.
 #older_than_days_threshold = 14
 
+#
+# detections_exclude_clouds =
+
 [logging]
 # Uncomment to request logging level (ERROR, WARN, INFO, DEBUG). Alternatively, use
 # LOG_LEVEL env variable.

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -7,6 +7,7 @@ backends =
 [events]
 severity_threshold = 2
 older_than_days_threshold = 21
+detections_exclude_clouds =
 
 [logging]
 level = INFO

--- a/fig/backends/__init__.py
+++ b/fig/backends/__init__.py
@@ -34,8 +34,11 @@ class Backends():
 
     def process(self, falcon_event):
         for runtime in self.runtimes:
-            if (runtime.RELEVANT_EVENT_TYPES == "ALL" or falcon_event.original_event.event_type in runtime.RELEVANT_EVENT_TYPES) and runtime.is_relevant(falcon_event):
+            if self.event_type_is_accepted(runtime, falcon_event) and runtime.is_relevant(falcon_event):
                 runtime.process(falcon_event)
+
+    def event_type_is_accepted(self, runtime, falcon_event):
+        return runtime.RELEVANT_EVENT_TYPES == "ALL" or falcon_event.original_event.event_type in runtime.RELEVANT_EVENT_TYPES
 
     @property
     def relevant_event_types(self):

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -50,13 +50,10 @@ class FigConfig(configparser.SafeConfigParser):
                     "Please provide environment variable {} or configuration option {}.{}".format(
                         envvar, section, var)) from err
 
-        if int(self.get('events', 'severity_threshold')) not in range(0, 5):
-            raise Exception('Malformed configuration: expected events.severity_threshold to be in range 0-4')
-        if int(self.get('events', 'older_than_days_threshold')) not in range(0, 10000):
-            raise Exception('Malformed configuration: expected events.older_than_days_threshold to be in range 0-10000')
         if int(self.get('main', 'worker_threads')) not in range(1, 128):
             raise Exception('Malformed configuration: expected main.worker_threads to be in range 1-128')
         self.validate_falcon()
+        self.validate_events()
         self.validate_backends()
 
     def validate_falcon(self):
@@ -66,6 +63,12 @@ class FigConfig(configparser.SafeConfigParser):
             raise Exception(
                 'Malformed configuration: expected falcon.cloud_region to be in {}'.format(self.FALCON_CLOUD_REGIONS)
             )
+
+    def validate_events(self):
+        if int(self.get('events', 'severity_threshold')) not in range(0, 5):
+            raise Exception('Malformed configuration: expected events.severity_threshold to be in range 0-4')
+        if int(self.get('events', 'older_than_days_threshold')) not in range(0, 10000):
+            raise Exception('Malformed configuration: expected events.older_than_days_threshold to be in range 0-10000')
 
     def validate_backends(self):
         if not self.backends.issubset(self.ALL_BACKENDS) or len(self.backends) < 1:

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -1,5 +1,6 @@
 import os
 import configparser
+from functools import cached_property
 
 
 class FigConfig(configparser.SafeConfigParser):
@@ -99,7 +100,7 @@ class FigConfig(configparser.SafeConfigParser):
             if len(self.get('azure', 'primary_key')) == 0:
                 raise Exception('Malformed Configuration: expected azure.primary_key to be non-empty')
 
-    @property
+    @cached_property
     def backends(self):
         return set(self.get('main', 'backends').split(','))
 


### PR DESCRIPTION
Sometimes users need to fine tune the detections that will be forwarded by the
fig. This change allows users to configure detection even filtering based on
cloud from which the detection comes from:

The following example will exclude detections coming from GCP cloud.

    [events]
    detections_exclude_clouds = GCP

Relates to https://github.com/CrowdStrike/falcon-integration-gateway/issues/130.