### PR TITLE
fix: update dockerfile + python deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3-slim-bullseye
+FROM docker.io/library/python:3-slim-bullseye@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf
 
 RUN : \
     && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/library/python:3-slim-bullseye@sha256:9f35f3a6420693c209c11bba63dcf103d88e47ebe0b205336b5168c122967edf
+FROM registry.access.redhat.com/ubi9/python-311
 
+USER root
 RUN : \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get upgrade --no-install-recommends --assume-yes \
-    && rm -rf /var/lib/apt/lists/*
+    && yum update -y \
+    && yum -y clean all --enablerepo='*'
 
 RUN useradd --create-home --home-dir /fig figuser
 WORKDIR /fig


### PR DESCRIPTION
Pin image used to build container to prevent container build issues. Newer images are now using python 3.12 which falconpy currently does not support. There's also an issue now with building python packages with gcc. This PR uses the last known good SHA prior to the breaking changes.