### PR TITLE
feat: add ability to pass in stream offset

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -21,6 +21,10 @@
 # Exclude events originating from certain cloud environments (AWS, Azure, GCP, or unrecognized)
 # detections_exclude_clouds =
 
+# Pass in the offset to start the stream from. This is useful to prevent duplicate events.
+# Alternatively, use EVENTS_OFFSET env variable. (default: 0)
+#offset = 0
+
 [logging]
 # Uncomment to request logging level (ERROR, WARN, INFO, DEBUG). Alternatively, use
 # LOG_LEVEL env variable.

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -8,6 +8,7 @@ backends =
 severity_threshold = 2
 older_than_days_threshold = 21
 detections_exclude_clouds =
+offset = 0
 
 [logging]
 level = INFO

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -13,6 +13,7 @@ class FigConfig(configparser.SafeConfigParser):
         ['logging', 'level', 'LOG_LEVEL'],
         ['events', 'severity_threshold', 'EVENTS_SEVERITY_THRESHOLD'],
         ['events', 'older_than_days_threshold', 'EVENTS_OLDER_THAN_DAYS_THRESHOLD'],
+        ['events', 'offset', 'EVENTS_OFFSET'],
         ['falcon', 'cloud_region', 'FALCON_CLOUD_REGION'],
         ['falcon', 'client_id', 'FALCON_CLIENT_ID'],
         ['falcon', 'client_secret', 'FALCON_CLIENT_SECRET'],


### PR DESCRIPTION
Don't know why, but the ability to pass in the offset was not something viable. This PR introduces the ability to start your stream from an offset via the configuration settings. 

1. You can either pass it in via the config.ini file `[events]::offset`
2. Alternatively, you can pass it in via the `EVENTS_OFFSET` environment variable.

⚠️ This will only be useful for event streams that only have 1 feed. For multi-feed event streams, it's best to handle it externally, or submit an issue requesting for this support to be added to a backend.