### PR TITLE
feat(aws): add confirm_instance to match original sechub int

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -73,7 +73,8 @@
 # Uncomment to provide aws region. Alternatively, use AWS_REGION env variable
 #region = eu-west-1
 
-# Uncomment to manage whether or not to confirm instance in region. Alternatively, use AWS_CONFIRM_INSTANCE env variable.
+# Uncomment to manage whether or not to confirm instance in AWS account supported region.
+# Alternatively, use AWS_CONFIRM_INSTANCE env variable.
 #confirm_instance = true
 
 [cloudtrail_lake]

--- a/config/config.ini
+++ b/config/config.ini
@@ -73,6 +73,9 @@
 # Uncomment to provide aws region. Alternatively, use AWS_REGION env variable
 #region = eu-west-1
 
+# Uncomment to manage whether or not to confirm instance in region. Alternatively, use AWS_CONFIRM_INSTANCE env variable.
+#confirm_instance = true
+
 [cloudtrail_lake]
 # AWS CloudTrail Lake section is applicable only when CLOUDTRAIL_LAKE backend is enabled in the [main] section.
 

--- a/config/defaults.ini
+++ b/config/defaults.ini
@@ -34,6 +34,7 @@ arc_autodiscovery = false
 
 [aws]
 region =
+confirm_instance = true
 
 [aws_sqs]
 region =

--- a/docs/aws/manual/README.md
+++ b/docs/aws/manual/README.md
@@ -143,6 +143,12 @@ You can either use the `config/config.ini` file or you can use environment varia
 
 ##### 3.2.1 Configure the FIG using the `config/config.ini` file
 
+> [!NOTE]
+> Instance existence confirmation can be disabled using the `confirm_instance` config.ini in
+> the `[aws]` section or by setting the `AWS_CONFIRM_INSTANCE` environment variable. This option is
+> available for scenarios where the account that is running the service application does not have
+> access to the AWS account where the instance with the detection resides.
+
 1. Modify the `config/config.ini` file and set the following minimum values:
 
     ```ini

--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -23,6 +23,7 @@ class FigConfig(configparser.ConfigParser):
         ['azure', 'primary_key', 'PRIMARY_KEY'],
         ['azure', 'arc_autodiscovery', 'ARC_AUTODISCOVERY'],
         ['aws', 'region', 'AWS_REGION'],
+        ['aws', 'confirm_instance', 'AWS_CONFIRM_INSTANCE'],
         ['aws_sqs', 'region', 'AWS_REGION'],
         ['aws_sqs', 'sqs_queue_name', 'AWS_SQS'],
         ['workspaceone', 'token', 'WORKSPACEONE_TOKEN'],
@@ -88,6 +89,8 @@ class FigConfig(configparser.ConfigParser):
         if 'AWS' in self.backends:
             if len(self.get('aws', 'region')) == 0:
                 raise Exception('Malformed Configuration: expected aws.region to be non-empty')
+            if self.get('aws', 'confirm_instance') not in ['false', 'true']:
+                raise Exception('Malformed Configuration: expected aws.confirm_instance must be either true or false')
         if 'AWS_SQS' in self.backends:
             if len(self.get('aws_sqs', 'region')) == 0:
                 raise Exception('Malformed Configuration: expected aws_sqs.region to be non-empty')


### PR DESCRIPTION
Adds new config option for AWS backend to control whether or not to skip matching on instance region. Generally this is useful for non MSSPs or users that need to support multiple aws accounts to one sechub instance.