### PR TITLE
fix: typo for AwsEc2Instance in AWS backend

### DIFF
--- a/fig/backends/aws/__init__.py
+++ b/fig/backends/aws/__init__.py
@@ -130,7 +130,7 @@ class Submitter():
         try:
             payload["Id"] = f"{self.event.instance_id}{self.event.event_id}"
             payload["Title"] = "Falcon Alert. Instance: %s" % self.event.instance_id
-            payload["Resources"] = [{"Type": "AwsEc2Instnace", "Id": self.event.instance_id, "Region": instance_region}]
+            payload["Resources"] = [{"Type": "AwsEc2Instance", "Id": self.event.instance_id, "Region": instance_region}]
         except AttributeError:
             payload["Id"] = f"UnknownInstanceID:{self.event.event_id}"
             payload["Title"] = "Falcon Alert"


### PR DESCRIPTION
I noticed events were coming into security hub under Type: `AwsEc2Instnace`. This fixes the typo.