### PR TITLE
fix(aws): check for network interfaces before trying to process

### DIFF
--- a/fig/backends/aws/__init__.py
+++ b/fig/backends/aws/__init__.py
@@ -24,11 +24,12 @@ class Submitter():
                 ec2instance = ec2.Instance(instance_id)
                 found = False
                 # Confirm the mac address matches
-                for iface in ec2instance.network_interfaces:
-                    det_mac = mac_address.lower().replace(":", "").replace("-", "")
-                    ins_mac = iface.mac_address.lower().replace(":", "").replace("-", "")
-                    if det_mac == ins_mac:
-                        found = True
+                if ec2instance.network_interfaces:
+                    for iface in ec2instance.network_interfaces:
+                        det_mac = mac_address.lower().replace(":", "").replace("-", "")
+                        ins_mac = iface.mac_address.lower().replace(":", "").replace("-", "")
+                        if det_mac == ins_mac:
+                            found = True
                 if found:  # pylint: disable=R1723
                     return region, ec2instance
             except ClientError:
@@ -75,9 +76,10 @@ class Submitter():
                                     self.event.instance_id, self.event.device_details["mac_address"])
                         return
                     try:
-                        for _ in instance.network_interfaces:
-                            # Only send alerts for instances we can find
-                            send = True
+                        if instance.network_interfaces:
+                            for _ in instance.network_interfaces:
+                                # Only send alerts for instances we can find
+                                send = True
 
                     except ClientError:
                         # Not our instance

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ disable=
     C0114,C0115,C0116,C0209,C0103,
     R0903,R0912,R0915,
     W0511,W0613,C0301,
-    W0719
+    W0719,R0917,R1702
 
 [pylint.DESIGN]
 max-parents=15


### PR DESCRIPTION
When `confirm_instance` is enabled - if boto3 returns an instance that does not have any network interfaces attached, this will cause the FIG to spit out an exception error for trying to iterate over a NoneType object.