### PR TITLE
chore: fix pip package build to include config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include config/*.ini

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/crowdstrike/falcon-integration-gateway",
     packages=find_packages(),
+    package_data={'': ['config/*.ini']},
     include_package_data=True,
     install_requires=[
         'boto3',


### PR DESCRIPTION
I must have had an unclean state as my previous testing looked to include this config dir to the package.