### PR TITLE
fix: fixes issue with loading config when not using package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY requirements.txt .
 RUN pip install -r ./requirements.txt
 
 COPY . .
+RUN chown -R figuser:figuser /fig
 
 USER figuser
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include config/*
+include config/*.ini

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/crowdstrike/falcon-integration-gateway",
     packages=find_packages(),
     package_data={
-        'fig': ['../config/*.ini'],
+        '': ['config/*.ini'],
     },
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
There was an issue with the latest changes to the config/__init__.py files that were made to support the updated python package. The problem was that on top of some errors with the python packaging config, we also stopped checking for what happens when you are running this from either the existing container or from the repository itself (aka, not using the pip package).