### PR TITLE
fix: fixed issue with severity values from detections being incorrect

### DIFF
--- a/fig/config/__init__.py
+++ b/fig/config/__init__.py
@@ -159,8 +159,8 @@ class FigConfig(configparser.ConfigParser):
                 'Malformed configuration: expected events.detections_exclude_clouds to be subset of "{}" got "{}"'.format(
                     self.SENSOR_RECOGNIZED_CLOUDS, self.detections_exclude_clouds))
 
-        if int(self.get('events', 'severity_threshold')) not in range(0, 5):
-            raise Exception('Malformed configuration: expected events.severity_threshold to be in range 0-4')
+        if int(self.get('events', 'severity_threshold')) not in range(1, 6):
+            raise Exception('Malformed configuration: expected events.severity_threshold to be in range 1-5')
         if int(self.get('events', 'older_than_days_threshold')) not in range(0, 10000):
             raise Exception('Malformed configuration: expected events.older_than_days_threshold to be in range 0-10000')
 


### PR DESCRIPTION
This was from the recent changes from DSE to EPPDSE event types. This fix maps based on the severity name instead of value. This currently maintains backwards compat for DSE events in some of the other backends and is just a simpler way to deal with this. Also added better logging to why an event is skipped. Unfortunately, since we support more than just Detections, I don't want to add a bunch of fields that are only relevant to one event type. Instead, we'll need to think through how best to provide someone with additional information..perhaps a verbosity level - 1 is what we have and 2 will print out the event payload itself?