### PR TITLE
fix: resolve linting issues in AWS backend and improve development setup

### DIFF
--- a/fig/backends/aws/__init__.py
+++ b/fig/backends/aws/__init__.py
@@ -213,7 +213,7 @@ class Submitter():
                     log.exception("Response processing exception details:")
                     log.debug("Raw response that caused error (Offset: %s): %s", self.event.original_event.offset, response)
 
-    def create_payload(self, instance_region):
+    def create_payload(self, instance_region):  # pylint: disable=too-many-locals
         region = self.region
         try:
             account_id = boto3.client("sts", region_name=region).get_caller_identity().get('Account')

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ exclude =
     venv
 max-line-length = 120
 max-complexity = 10
-ignore = C901,E501
+ignore = C901,E501,W503,W504
 
 [pylint.MASTER]
 disable=


### PR DESCRIPTION
This commit addresses two specific linting issues identified in the AWS backend:

1. **Flake8 W504 Resolution**: 
   - The W504 (line break after binary operator) and W503 (line break before binary operator) 
     rules are mutually exclusive and both are acceptable per PEP 8
   - Added both W503 and W504 to the flake8 ignore list in setup.cfg to resolve this conflict
   - Maintained the existing code style in _is_aws_event() method

2. **Pylint R0914 Resolution**:
   - Added targeted pylint disable comment for "too-many-locals" rule on create_payload method
   - This is a focused disable that doesn't affect other methods or files
   - The method legitimately needs multiple variables for payload construction

**Verification**:
- flake8 fig: ✅ passes with no errors
- pylint fig: ✅ passes with 10.00/10 rating
- All existing functionality preserved