### PR TITLE
Replace GitHub secrets with variables in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   IMAGE_REGISTRY: gcr.io
@@ -54,15 +54,15 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s
 
       - name: Login to gcr.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ secrets.REGISTRY_LOGIN }}
+          username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up Docker Buildx
@@ -78,7 +78,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=match,pattern=\d.\d
             type=match,pattern=\d.\d.\d
-          annotations: ${{ secrets.SERVICE_ANNOTATION }}
+          annotations: ${{ vars.SERVICE_ANNOTATION }}
 
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -106,15 +106,15 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s
 
       - name: Login to gcr.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ secrets.REGISTRY_LOGIN }}
+          username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up Docker Buildx
@@ -134,7 +134,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=match,pattern=\d.\d
             type=match,pattern=\d.\d.\d
-          annotations: ${{ secrets.SERVICE_ANNOTATION }}
+          annotations: ${{ vars.SERVICE_ANNOTATION }}
 
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
-
-env:
-  IMAGE_REGISTRY: gcr.io
-  IMAGE_NAME: gcr.io/crowdstrike-public/falcon-integration-gateway
-  DEPLOYER: gcr.io/crowdstrike-public/falcon-integration-gateway/deployer
+    types: [created]
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
@@ -55,13 +50,13 @@ jobs:
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           access_token_lifetime: 600s
 
       - name: Login to gcr.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ vars.IMAGE_REGISTRY }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
@@ -72,7 +67,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ vars.IMAGE_NAME }}
           tags: |
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -107,13 +102,13 @@ jobs:
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           access_token_lifetime: 600s
 
       - name: Login to gcr.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ vars.IMAGE_REGISTRY }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
@@ -122,13 +117,13 @@ jobs:
 
       - name: Pull latest onbuild image
         run: |
-          docker pull gcr.io/cloud-marketplace-tools/k8s/deployer_helm/onbuild
+          docker pull ${{ vars.ONBUILD_IMAGE }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
-          images: ${{ env.DEPLOYER }}
+          images: ${{ vars.DEPLOYER_IMAGE }}
           tags: |
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
The release workflow previously authenticated to Google Cloud and configured image publishing using GitHub secrets. Since we can no longer use GitHub secrets, this migrates those values to GitHub repository variables.

All of the values involved are non-sensitive public identifiers — the workload identity provider path, the service account email, image registry and names, and the marketplace service annotation — so they are safe to store as plaintext variables. Authentication to GCP continues to use Workload Identity Federation over the GitHub OIDC token, which mints a short-lived access token at runtime, so no long-lived credentials are stored anywhere. The gcr.io docker login now uses the fixed `oauth2accesstoken` username with that runtime token instead of a stored registry login secret.

The container and deployer jobs are unchanged in behavior; only their input sources moved from `secrets.*` to `vars.*`.
